### PR TITLE
security: remove hardcoded DB password and JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Prerequisites: JDK 17 and a running MySQL instance.
 git clone https://github.com/itswael/BikeGarage.git
 cd BikeGarage
 
-# configure src/main/resources/application.properties with your own
-# database URL/credentials and JWT secret before running
+export DB_URL="jdbc:mysql://localhost:3306/bikegarage"
+export DB_USERNAME="root"
+export DB_PASSWORD="your-mysql-password"
+export JWT_SECRET="your-own-random-secret"
 
 ./mvnw clean install
 ./mvnw spring-boot:run
@@ -44,7 +46,7 @@ cd BikeGarage
 
 The API is served under `/api` (e.g. `/api/auth/login`, `/api/auth/google`, `/api/services/**`, `/api/vehicles/**`).
 
-> **Note:** `application.properties` in this repository is a local development file. Replace the database credentials and `jwt.secret` with your own values rather than reusing the committed ones.
+> **Note:** database credentials and the JWT secret are read from environment variables (`DB_URL`, `DB_USERNAME`, `DB_PASSWORD`, `JWT_SECRET`) — nothing sensitive is committed in `application.properties`.
 
 ## Contributing
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,11 @@
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
-spring.datasource.url=jdbc:mysql://localhost:3306/bikegarage
-spring.datasource.username=root
-spring.datasource.password=Wrogn@2024
+spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/bikegarage}
+spring.datasource.username=${DB_USERNAME:root}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.flyway.baseline-on-migrate = true
 spring.application.name=backend
 debug=true
 logging.level.org.springframework.security=trace
-jwt.secret=mySuperSecretKeyForJWT123456789012345678901234567890
+jwt.secret=${JWT_SECRET}


### PR DESCRIPTION
Replaces the hardcoded MySQL password (`Wrogn@2024`) and JWT secret in `application.properties` with environment-variable placeholders (`DB_URL`, `DB_USERNAME`, `DB_PASSWORD`, `JWT_SECRET`). These were committed in plaintext in this public repo.

**Still needed after merging (manual, can't be done from here):**
- Rotate the MySQL password on the actual database server
- Generate and set a new `JWT_SECRET` value wherever this is deployed
- Consider scrubbing the old values from git history (e.g. via `git filter-repo`) since this is a public repo and the old values may already be cached/cloned elsewhere